### PR TITLE
remove http status assertions

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -77,8 +77,6 @@ response.prototype = {
    */
 
   set status(code) {
-    assert('number' == typeof code, 'status code must be a number');
-    assert(statuses[code], 'invalid status code: ' + code);
     this._explicitStatus = true;
     this.res.statusCode = code;
     this.res.statusMessage = statuses[code];


### PR DESCRIPTION
These assertions are causing me grief. In using x-ray and x-ray-crawler, the crawler comes upon some pages and assets that return HTTP 999. I know, I know, it is not a valid HTTP Status, but the reality is that there are some HTTP servers out there that are not following the rules.

I suggest that these assertions are removed.
